### PR TITLE
Fixed typo canavs -> canvas

### DIFF
--- a/src/res/wasm_interface.h
+++ b/src/res/wasm_interface.h
@@ -31,7 +31,7 @@ void step(size_t num_balls, float delta);
  * Pixels are represented as 4 byte chunks of RGBA. Feel free to use a u32 with
  * 0xaabbggrr
  *
- * Note that canavs_width * canvas_height may be less than max_canvas_size, but
+ * Note that canvas_width * canvas_height may be less than max_canvas_size, but
  * will never be greater
  *
  * canvasMemory() can be re-used between frames, so free to re-use previous


### PR DESCRIPTION
Was reading the tutorial and now that I know the typo is there, I can't unsee it.

Sorry, I know it's not important but I still went ahead and created the PR, I leave the rest to you :D
